### PR TITLE
Add `environment.yml` for mybinder.org demos

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,4 @@
+channels:
+  - conda-forge
+dependencies:
+- nbtutor


### PR DESCRIPTION
Hi 👋 !

This is a very cool extension! I wanted to try it out and as I am one of the project leads for mybinder.org (turns a Git repo into interactive, executable notebooks) checked if it would run there. This PR is the small addition needed to make it work.

It tells binder to install the conda package, done.

[Try it yourself](https://mybinder.org/v2/gh/betatim/nbtutor/betatim-patch-1?filepath=examples%2Fusage.ipynb)

If you like it we can also add a badge like [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/betatim/nbtutor/betatim-patch-1?filepath=examples%2Fusage.ipynb) this to the readme for people to try out.